### PR TITLE
Remove custom aarch64 support hack 

### DIFF
--- a/arm.Dockerfile
+++ b/arm.Dockerfile
@@ -6,8 +6,7 @@ COPY .cargo/ .cargo/
 
 RUN rustup target add wasm32-unknown-unknown
 RUN cargo install -f wasm-bindgen-cli
-# wasm-opt HACK for aarch64
-RUN cargo install --git https://github.com/dkristia/wasm-pack-aarch64 wasm-pack
+RUN cargo install wasm-pack
 
 COPY rustend/ rustend/
 


### PR DESCRIPTION
aarch64 is now natively supported in wasm-pack