### PR TITLE
fix(docker): update Rust to 1.84 in Dockerfiles

### DIFF
--- a/arm.Dockerfile
+++ b/arm.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/aarch64 arm64v8/rust:1.78-slim-buster as rust
+FROM --platform=linux/aarch64 arm64v8/rust:1.84-slim-buster as rust
 
 WORKDIR /app
 

--- a/x86_64.Dockerfile
+++ b/x86_64.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.78-slim-buster as rust
+FROM rust:1.84-slim-buster as rust
 
 WORKDIR /app
 


### PR DESCRIPTION
Dependencies are complaining about an outdated version of rust